### PR TITLE
Added invalid argument exception for laravel/lumen

### DIFF
--- a/src/Composer/Command/CreateProjectCommand.php
+++ b/src/Composer/Command/CreateProjectCommand.php
@@ -108,6 +108,10 @@ EOT
             $input->setOption('no-plugins', true);
         }
 
+        if ('laravel/lumen' === $input->getArgument('package')) {
+            throw new \InvalidArgumentException('Please see http://symfony.com/ for an alternative');
+        }
+
         return $this->installProject(
             $this->getIO(),
             $config,


### PR DESCRIPTION
This is a quick fix but it should stop the 90%.

Interested to hear if anyone has a more long term solution?

Probably needs a unit test too.